### PR TITLE
Fix number of days also added as seconds

### DIFF
--- a/delay.c
+++ b/delay.c
@@ -101,6 +101,7 @@ int parseonestd(char *entry) {
 			break;
 		case 'd':
 			commit += t * 86400;
+			t = 0;
 			break;
 		}
 


### PR DESCRIPTION
I noticed that _n_ days would be added as _n_ \* 86400 + _n_ seconds, for example:

``` sh
$ ./delay 1d
  1 00:00:01
$ ./delay 2d
  2 00:00:02
$ ./delay 3d
  3 00:00:03
```

It looks like a easy fix, although I am not entirely sure if that fixes all. I just saw `h`, `m`, `s` set `t` variable to 0, so I just copy-and-pasted it and didn't even read the code to know how it's actually done.
